### PR TITLE
Added option to validate the files instead of sorting them.

### DIFF
--- a/Sources/update-strings/Commands/SortCommand.swift
+++ b/Sources/update-strings/Commands/SortCommand.swift
@@ -44,7 +44,7 @@ struct SortCommand: ParsableCommand {
             
             guard currentStrings != newStrings else { continue }
             
-            print("\(dryRun ? "Validating" : "Sorting") \(relativePath)")
+            print("Sorting \(relativePath)")
             
             if dryRun {
                 unsortedStringPaths.append(relativePath)
@@ -54,11 +54,10 @@ struct SortCommand: ParsableCommand {
         }
         
         if dryRun, !unsortedStringPaths.isEmpty {
-            throw ValidationError(
-                unsortedStringPaths
-                    .map { "\($0) is not sorted." }
-                    .joined(separator: "\n")
-            )
+            print("The following files need to be sorted.")
+            unsortedStringPaths.forEach { print($0) }
+            
+            throw ExitCode.failure
         }
     }
 }


### PR DESCRIPTION
## Description of changes
* Added `--dry-run` option in the sort command to validate if the string files are sorted. it throws an error with all unsorted files.
* Changed the sort command logging so it only prints if the contents of the file will be sorted/validated.